### PR TITLE
Change import to commonjs require in main

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -1,21 +1,11 @@
 /* eslint global-require: off */
 
-/**
- * This module executes inside of electron's main process. You can start
- * electron renderer process from here and communicate with the other processes
- * through IPC.
- *
- * When running `yarn build` or `yarn build-main`, this file is compiled to
- * `./app/main.prod.js` using webpack. This gives us some performance wins.
- *
- * @flow
- */
-import { app, BrowserWindow } from "electron"
-import { autoUpdater } from "electron-updater"
-import log from "electron-log"
-import MenuBuilder from "./menu"
+const { app, BrowserWindow } = require("electron")
+const { autoUpdater } = require("electron-updater")
+const log = require("electron-log")
+const MenuBuilder = require("./menu")
 
-export default class AppUpdater {
+class AppUpdater {
   constructor() {
     log.transports.file.level = "info"
     autoUpdater.logger = log
@@ -111,3 +101,5 @@ app.on("activate", () => {
   // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) createWindow()
 })
+
+module.exports = AppUpdater

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,6 +1,6 @@
-import { app, Menu, shell, BrowserWindow } from "electron"
+const { app, Menu, shell, BrowserWindow } = require("electron")
 
-export default class MenuBuilder {
+class MenuBuilder {
   constructor(mainWindow = BrowserWindow) {
     this.mainWindow = mainWindow
   }
@@ -272,3 +272,5 @@ export default class MenuBuilder {
     return templateDefault
   }
 }
+
+module.exports = MenuBuilder


### PR DESCRIPTION
direct electron app/main.dev.js throw error so change to common js require

```bash
$ electron app/main.dev.js 
App threw an error during load
/Users/yoyota/hobby/electron-react-boilerplate-minimal/app/main.dev.js:13
import { app, BrowserWindow } from "electron"
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at Module._compile (internal/modules/cjs/loader.js:815:22)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:892:10)
    at Module.load (internal/modules/cjs/loader.js:735:32)
    at Module._load (internal/modules/cjs/loader.js:648:12)
    at Module._load (electron/js2c/asar.js:717:26)
    at Function.Module._load (electron/js2c/asar.js:717:26)
    at loadApplicationPackage (/Users/yoyota/hobby/electron-react-boilerplate-minimal/node_modules/electron/dist/Electron.app/Contents/Resources/default_app.asar/main.js:109:16)
    at Object.<anonymous> (/Users/yoyota/hobby/electron-react-boilerplate-minimal/node_modules/electron/dist/Electron.app/Contents/Resources/default_app.asar/main.js:155:9)
    at Module._compile (internal/modules/cjs/loader.js:880:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:892:10)
```